### PR TITLE
incorrect name and discontinued link, resolves #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Starts from simple stuff like load balancing and message queues, then moves to b
 * [david malans cs75 scalability talk](https://www.youtube.com/watch?v=-W9F__D3oY4&list=PLmhRNZyYVpDmLpaVQm3mK5PY5KB_4hLjE&index=10)
 Feel free to go through other lectures if needed. 
 
-* [david huffman's talk , scaling up talk](https://www.udacity.com/course/web-development--cs253) ([Youtube link](https://www.youtube.com/watch?v=pjNTgULVVf4&list=PLVi1LmRuKQ0NINQfjKLVen7J2lZFL35wP&index=1))
+* [Steve huffman's ,Reddit scaling up talks](https://www.youtube.com/watch?v=pjNTgULVVf4&list=PLVi1LmRuKQ0NINQfjKLVen7J2lZFL35wP&index=1)
 
 * [scalability for dummies](http://www.lecloud.net/tagged/scalability)
 


### PR DESCRIPTION
Removed incorrect name and Udacity course link as it's discontinued.